### PR TITLE
Modernized error handler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,5 +3,11 @@
     "description": "Core52: Rapid development MVC Framework for PHP - Official Repository",
     "type": "framework",
     "license": "MIT",
-    "require": {}
+    "require": {},
+    "require-dev": {
+        "filp/whoops": "^2.1"
+    },
+    "suggest": {
+        "sentry/sentry": "Report errors to Sentry.io"
+    }
 }

--- a/exceptions.php
+++ b/exceptions.php
@@ -7,10 +7,7 @@ set_error_handler(array('ErrorCore', 'handle_error'), E_ALL ^ E_NOTICE);
 assert_options(ASSERT_ACTIVE, 0);
 ini_set('track_errors', 'On');
 
-
 class FatalErrorException extends ErrorException {}
-class DatabaseException extends Exception {}
-class DatabaseConnectionException extends Exception {}
 class PageNotFoundException extends Exception {}
 class AccessDeniedException extends Exception {}
 class SecurityException extends Exception {}
@@ -18,479 +15,347 @@ class XSRFSecurityException extends SecurityException {}
 class UploadException extends Exception {}
 class FormException extends Exception {}
 
+class DatabaseException extends Exception
+{
+	public $query;
+	public $recentQueries = array();
 
-class ErrorCore {
+	public static function factory($c)
+	{
+		$exception = new self($c->error_msg(), $c->error_code());
+		$exception->setQuery($c->last_query());
+		$exception->setRecentQueries($c->query_history);
+		return $exception;
+	}
 
+	public function setQuery($query)
+	{
+		$this->query = $query;
+	}
+
+	public function setRecentQueries(array $recentQueries = array())
+	{
+		$this->recentQueries = $recentQueries;
+	}
+}
+
+class DatabaseConnectionException extends DatabaseException {}
+
+class ErrorCore
+{
 	const DISPLAY_HALT = 1;
 	const DISPLAY_CONTINUE = 2;
 	const SILENT_CONTINUE = 4;
 	
-	
-	public static function _print_error_header() {
+	public static function handle_error($code, $message, $file, $line, $context)
+    {
+		if (error_reporting() == 0)
+        {
+            return true;
+        }
 
-		$core_rev = svn_get_version(PATH_CORE, FALSE);
-		$app_rev = svn_get_version(PATH_APP, FALSE);
-		
-?>
-<html>
-<head>
-<title>System Error</title>
-<style type="text/css">
-	span.value { font-style:italic; }
-	span.a_key, span.o_key { font-weight:bold; }
-	pre, code { display:block; padding:12px; margin:12px 0; background:#eeeeee; border-top:3px solid #ccc; border-bottom:3px solid #ccc; }
-	ol { margin-left:0; }
-	li { margin-left:0px; padding-bottom:12px; }
-	h1, h2, h3 { margin-top:25px; margin-bottom:18px; }
-</style>
-</head>
-<body id="main">
-	<div style="padding:40px;">
-		<p><em>Running Core52 rev. <?=$core_rev;?>, app rev. <?=$app_rev;?></em></p>
-<?php
-
-	}
-	
-	
-	public static function _print_error_backtrace($exception) {
-
-?>
-		<h2>Backtrace:</h2>
-		
-		<ol>
-<?php
-			
-			$cnt = 0;
-			#print_r($exception->getTrace()); die;
-			#$prev_args = array();
-			$trace = $exception->getTrace();
-			foreach($trace as $i => $line) {
-				$args = (array) $line['args'];
-				foreach((array) $args as $i => $arg) {
-					if(is_array($arg)) {
-						$args[$i] = print_r($arg, TRUE);
-					}
-					elseif(is_object($arg)) {
-						$args[$i] = '['.get_class($arg).' object]';
-					}
-					elseif(is_numeric($arg)) {
-						$args[$i] = $arg;
-					}
-					elseif(is_null($arg)) {
-						$args[$i] = 'NULL';
-					}
-					elseif($arg === TRUE) {
-						$args[$i] = 'TRUE';
-					}
-					elseif($arg === FALSE) {
-						$args[$i] = 'FALSE';
-					}
-					else {
-						$args[$i] = "&quot;$arg&quot;";
-					}
-				}
-				$args = implode(', ', $args);
-				if(strlen($args) > 128) $args = '[omitted]';
-				echo "		<li><b>{$line['class']}{$line['type']}{$line['function']}(</b>$args<b>)</b><br />\n     <i>called at</i> <b>{$line['file']}[{$line['line']}]</b>\n\n</li>";
-				$cnt++;
-				#$prev_args = $line['args'];
-			}
-?>
-		</ol>
-<?php
-
-	}
-	
-	
-	public static function _print_error_footer() {
-
-?>
-	</div>
-</body>
-</html>
-<?php
-
-	}
-	
-	public static function _print_error_message($exception) {
-
-?>
-		<h1><?=get_class($exception);?></h1>
-		<p>An error has occured in <b><?=$exception->getFile();?></b> line <b><?=$exception->getLine();?></b>:</p>
-		<code><?=$exception->getMessage();?></code>
-<?php
-
-	}
-	
-	
-	public static function _print_query_backtrace($exception) {
-?>
-		<h1><?=get_class($exception);?></h1>
-		<p>A <b>MySQL Query Error #<?=database()->error_code();?></b> has occured in <b><?=$exception->getFile();?></b> line <b><?=$exception->getLine();?></b>:</p>
-		<code><?=$exception->getMessage();?></code>
-		<h2>Most Recent Queries:</h2>
-		<ol>
-		<? foreach(Database::c()->query_history as $i => $q): ?>
-			<li><b><?=$q->call;?></b><br />
-			<em>Called in</em> <b><?=$q->file;?>[<?=$q->line;?>]</b>
-			<code><?=$q->query;?></code></li>
-		<? endforeach; ?>
-		</ol>
-		
-<?php
-	}
-	
-	
-	public static function handle_exception($exception, $halt = ErrorCore::DISPLAY_HALT) {
-		
-		try {
-	    	
-	    	switch(get_class($exception)) {
-	    	
-	    		case 'PageNotFoundException':
-		    		while(ob_get_level()) ob_end_clean();
-					self::show_404();
-		    	break;
-		    		
-	    		case 'AccessDeniedException':
-	    			while(ob_get_level()) ob_end_clean();
-					self::show_403();
-	    		break;
-	    		
-	    		case 'XSRFSecurityException':
-	    			while(ob_get_level()) ob_end_clean();
-	    			self::show_xsrf();
-	    		break;
-		    		
-		    	case 'DatabaseException':
-				case 'DatabaseConnectionException':
-		    		ob_start();
-		    		self::_print_error_header();
-					echo $exception->getMessage();
-					
-					// Don't show the backtrace when there is a DatabaseConnectionException
-					// This keeps the database password from being exposed.
-					if (get_class($exception) != 'DatabaseConnectionException') {
-						self::_print_error_backtrace($exception);
-					}
-						
-					self::_print_error_footer();
-					ErrorCore::report(ob_get_clean(), $exception, $halt);
-		    	break;
-	    		
-		    	case 'ErrorException':
-		    	default:
-		    		ob_start();
-		    		self::_print_error_header();
-		    		self::_print_error_message($exception);
-					self::_print_error_backtrace($exception);
-		    		self::_print_error_footer();
-		    		ErrorCore::report(ob_get_clean(), $exception, $halt);
-				break;
-		    }
-		    
-		    if($halt == ErrorCore::DISPLAY_HALT) core_halt();
-		    
-	    }
-	    catch (Exception $e) {
-	        echo get_class($e)." thrown within the exception handler. Message: <pre>$e</pre>";
-	        core_halt();
-	    }
-	}
-	
-	
-	public static function handle_error($code, $message, $file, $line, $context) {
-		
-		if(error_reporting() == 0) return TRUE;
-	    
-	    switch($code) {
-			
+	    switch($code)
+        {
 			case 65536:
-				
 				throw new DatabaseException($message);
 				break;
-			
-			case E_STRICT:
-			case E_NOTICE:
 
-				/*
-				if(class_exists('FirePHP') && DEV_MODE){
-					$fb = new FirePHP();
-	    			$e = new ErrorException($message, 0, $code, $file, $line);
-					$fb->fb($e);
-				}
-				return true;
-				*/
-				
-				return TRUE;
-				
 			default:
-					
 				throw new ErrorException($message, $code, 0, $file, $line);
 				break;
-				
 		}
-	    
 	}
 	
+	public static function handle_exception($exception, $halt = ErrorCore::DISPLAY_HALT)
+	{
+        try
+        {
+			error_log($exception);
+
+			switch (get_class($exception))
+			{
+				case 'PageNotFoundException':
+					return self::show_404();
+
+				case 'AccessDeniedException':
+					return self::show_403();
+
+				case 'XSRFSecurityException':
+					return self::show_xsrf();
+            }
+			
+			if (Config::get('RAVEN_DSN', false))
+            {
+                self::handle_exception_raven($exception);
+            }
+            elseif (Config::get('SHOW_ERROR_TRACE', false))
+            {
+                self::handle_exception_verbose($exception);
+			}
+			else
+			{
+				self::handle_exception_default($exception);
+			}
+        }
+        catch (Exception $e)
+        {
+            try
+            {
+                self::handle_exception_default($exception);
+            }
+            catch (Exception $e)
+            {
+                error_log($e);
+				echo $e;
+            }
+        }
+		
+		if ($halt == ErrorCore::DISPLAY_HALT)
+		{
+			core_halt();
+		}
+    }
+
+	public static function handle_exception_raven($exception)
+    {
+        $package = json_decode(file_get_contents(dirname(__DIR__) . DIRECTORY_SEPARATOR . 'package.json'));
+
+        $client = new Raven_Client(Config::get('RAVEN_DSN'), array(
+            'name' => PHP_SAPI === 'cli' ? realpath($_SERVER['argv'][0]) : Config::get('HOSTNAME'),
+            'release' => $package->version,
+            'app_path' => PATH_APP,
+        ));
+
+        $client->extra_context(array(
+            'php_version' => phpversion(),
+            'php_sapi' => PHP_SAPI,
+        ));
+
+        if (PHP_SAPI !== 'cli')
+        {
+            if (!empty($_SESSION))
+            {
+                $client->extra_context(array(
+                    'session' => $_SESSION,
+                ));
+            }
+
+            $user = User::get_current_user(User::USER_ERROR_FALSE);
+            if ($user)
+            {
+                $client->user_context($user->toArray());
+            }
+        }
+
+		if ($exception instanceof DatabaseException)
+		{
+			$recentQueries = array();
+			foreach ($exception->recentQueries as $query)
+			{
+				$key = $query->file . ':' . $query->line;
+				$value = (string) $query->query;
+				$recentQueries[$key] = $value;
+			}
+
+			$client->extra_context(array(
+				'errorCode' => $exception->getCode(),
+				'errorQuery' => $exception->query,
+				'recentQueries' => $recentQueries
+			));
+		}
+		
+		$client->captureException($exception);
+    }
+    
+    public static function handle_exception_verbose($exception)
+    {
+        $whoops = new \Whoops\Run;
+
+        if (PHP_SAPI === 'cli')
+        {
+            $whoops->pushHandler(new \Whoops\Handler\PlainTextHandler);
+        }
+        elseif (Router::is_ajax())
+        {
+            $handler = new \Whoops\Handler\JsonResponseHandler();
+            $handler->addTraceToOutput(true);
+            $whoops->pushHandler($handler);
+        }
+        else
+        {
+            $handler = new \Whoops\Handler\PrettyPageHandler();
+
+            if ($exception instanceof DatabaseException)
+            {
+                $handler->addDataTable('Database Error', array(
+                    'Query' => (string) $exception->query,
+                    'Error' => 'MySQL Error #' . $exception->getCode() . ': ' . $exception->getMessage(),
+                    //'recentQueries' => $exception->recentQueries
+                ));
+
+                $recentQueries = array();
+                foreach ($exception->recentQueries as $query)
+                {
+                    $key = $query->file . ':' . $query->line;
+                    $value = (string) $query->query;
+                    $recentQueries[$key] = $value;
+                }
+
+                $handler->addDataTable('Recent Database Queries', $recentQueries);
+            }
+
+            $user = User::get_current_user(User::USER_ERROR_FALSE);
+            if ($user)
+            {
+                $handler->addDataTable('User', $user->toArray());
+            }
+
+            $whoops->pushHandler($handler);
+        }
+        
+		if (PHP_SAPI !== 'cli')
+		{
+            header('HTTP/1.1 500 Internal Server Error', true, 500);
+        }
+
+        echo $whoops->handleException($exception);
+	}
 	
-	public static function show_404() {
-		header('http/1.0 404 Not Found');
+	public static function handle_exception_default($exception)
+	{
+		if (PHP_SAPI === 'cli')
+		{
+			echo $exception;
+		}
+		elseif (Router::is_ajax())
+		{
+			header('HTTP/1.1 500 Internal Server Error', true, 500);
+			echo json_encode(array(
+				'error' => array(
+					'type' => get_class($exception),
+					'message' => $exception->getMessage(),
+					'code' => $exception->getCode()
+				)
+			));
+		}
+		else
+		{
+			header('HTTP/1.1 500 Internal Server Error', true, 500);
+			@FastView::Load('errors/error');
+			@FastView::Publish();
+		}
+	}
+
+	public static function show_404()
+	{
+		header('HTTP/1.1 404 Not Found', true, 404);
+
 		$headers = headers_list();
 		$mime = 'text/html';
-		foreach($headers as $header) {
-			if(preg_match('/content-type:/i', $header)) {
+		foreach ($headers as $header)
+		{
+			if (preg_match('/content-type:/i', $header))
+			{
 				list(, $mime) = explode(':', $header);
 			}
 		}
-		if($mime == 'text/html') {
-			if(file_exists(PATH_VIEWS .'http/404'. TPL_EXT)) {
-				View::Load('http/404');
-				View::Parse();
-				View::Publish();
-			} elseif(file_exists(PATH_VIEWS .'errors/404'. TPL_EXT)) {
-				View::Load('errors/404');
-				View::Parse();
-				View::Publish();
-			} else {
+
+		if ($mime == 'text/html')
+		{
+			if (file_exists(PATH_VIEWS .'http/404.php'))
+			{
+				@FastView::Load('http/404');
+				@FastView::Publish();
+			}
+			elseif (file_exists(PATH_VIEWS .'errors/404.php'))
+			{
+				@FastView::Load('errors/404');
+				@FastView::Publish();
+			}
+			else {
 				echo '<h1>HTTP 404 Page Not Found</h1>';
 			}
 		}
+
 		core_halt();
 	}
 	
-	
-	public static function show_403() {
-		header('http/1.0 403 Forbidden');
+	public static function show_403()
+	{
+		header('HTTP/1.1 403 Forbidden', true, 403);
+
 		$headers = headers_list();
 		$mime = 'text/html';
-		foreach($headers as $header) {
-			if(preg_match('/content-type:/i', $header)) {
+		foreach ($headers as $header)
+		{
+			if (preg_match('/content-type:/i', $header))
+			{
 				list(, $mime) = explode(':', $header);
 			}
 		}
-		if($mime == 'text/html') {
-			if(file_exists(PATH_VIEWS .'http/403'. TPL_EXT)) {
-				View::Load('http/403');
-				View::Parse();
-				View::Publish();
-			} elseif(file_exists(PATH_VIEWS .'errors/403'. TPL_EXT)) {
-				View::Load('errors/403');
-				View::Parse();
-				View::Publish();
-			} else {
+
+		if ($mime == 'text/html')
+		{
+			if(file_exists(PATH_VIEWS .'http/403.php'))
+			{
+				@FastView::Load('http/403');
+				@FastView::Publish();
+			}
+			elseif (file_exists(PATH_VIEWS .'errors/403.php'))
+			{
+				@FastView::Load('errors/403');
+				@FastView::Publish();
+			}
+			else
+			{
 				echo '<h1>HTTP 403 Forbidden</h1>';
 			}
 		}
+
 		core_halt();
 	}
 	
-	
-	public static function show_xsrf() {
-		if(Router::is_ajax()) {
-			
+	public static function show_xsrf()
+	{
+		header('HTTP/1.1 403 Forbidden', true, 403);
+
+		if (Router::is_ajax())
+		{
 			// try not to break AJAX applications
 			json_output((object) array(), 'This page has expired, please refresh the page and try again.');
-			
-		} else {
-			
+		}
+		else
+		{
 			// determine the page MIME type
-			header('http/1.0 403 Forbidden');
 			$headers = headers_list();
 			$mime = 'text/html';
-			foreach($headers as $header) {
-				if(preg_match('/content-type:/i', $header)) {
+			foreach($headers as $header)
+			{
+				if (preg_match('/content-type:/i', $header))
+				{
 					list(, $mime) = explode(':', $header);
 				}
 			}
 			
-			if($mime == 'text/html') {
-				if(file_exists(PATH_VIEWS .'http/xsrf'. TPL_EXT)) {
-					View::Load('http/xsrf');
-					View::Parse();
-					View::Publish();
-				} elseif(file_exists(PATH_VIEWS .'errors/xsrf'. TPL_EXT)) {
-					View::Load('errors/xsrf');
-					View::Parse();
-					View::Publish();
-				} else {
+			if($mime == 'text/html')
+			{
+				if(file_exists(PATH_VIEWS .'http/xsrf.php'))
+				{
+					@FastView::Load('http/xsrf');
+					@FastView::Publish();
+				}
+				elseif (file_exists(PATH_VIEWS .'errors/xsrf.php'))
+				{
+					@FastView::Load('errors/xsrf');
+					@FastView::Publish();
+				}
+				else
+				{
 					echo sprintf('<h1>This page has expired</h1><p>Please <a href="%s">click here</a> to reload the page and try again.</p>', Router::url());
 				}
 			}
 		}
+
 		core_halt();
 	}
-	
-	
-	public static function report($html, $e = NULL, $halt = ErrorCore::DISPLAY_HALT) {
-		
-		$email_debug_rcpt = Config::get('EMAIL_DEBUG_RCPT', FALSE);
-		if(!empty($email_debug_rcpt)) {
-			
-			$mailer = Mailer::factory();
-			
-			if(PHP_SAPI === 'cli') {
-				$mailer->Subject = sprintf(
-					'%s script error in %s',
-					defined('APP_NAME')? APP_NAME : "Core52",
-					$_SERVER['PHP_SELF']
-				);
-			} else {
-				$mailer->Subject = sprintf(
-					'%s page error in %s',
-					defined('APP_NAME')? APP_NAME : "Core52",
-					Router::url()
-				);
-			}
-			
-			$mailer->Body = $html;
-			$mailer->AltBody = "An unexpected error occurred!\n\n";
-			
-			$attachments = array();
-			$attachments['session.html'] = (defined('ENABLE_LEGACY_SESSIONS'))? dump(Session::$data) : dump($_SESSION);
-			if(count($_GET))  $attachments['get.html']  = dump($_GET);
-			if(count($_POST)) $attachments['post.html'] = dump($_POST);
-			if(count($_SERVER)) $attachments['server.html'] = dump($_SERVER);
-			foreach($attachments as $filename => $contents) {
-				$mailer->AddStringAttachment($contents, $filename);
-			}
-			
-			foreach((array) Config::get('EMAIL_DEBUG_RCPT') as $addr) {
-				$mailer->AddAddress($addr);
-			}
-			if(Session::get(FALSE)) {
-				$mailer->From = Session::user()->email;
-			}
-			
-			if(defined('QUEUE_ERROR_EMAILS')) {
-				$mailer->queue();
-			} else {
-				$mailer->send();
-			}
-			
-			if($halt === ErrorCore::DISPLAY_HALT || $halt === ErrorCore::DISPLAY_CONTINUE) {
-				if(PHP_SAPI === 'cli' && $e instanceof Exception) {
-					echo str_repeat('=', 80).PHP_EOL;
-					echo $e;
-					echo PHP_EOL.str_repeat('=', 80).PHP_EOL;
-				} elseif(PHP_SAPI != 'cli' && !Router::is_ajax() && file_exists(PATH_VIEWS.'errors/error.php')) {
-					include(PATH_VIEWS.'errors/error.php');
-				} else {
-					echo "\n\nAn unexpected error occurred!\n\n";
-				}
-				
-				if($halt === ErrorCore::DISPLAY_HALT) {
-					core_halt();
-				}
-			}
-			
-		} else {
-			
-			$buf_status = ob_get_status(TRUE);
-			
-			if($halt === ErrorCore::DISPLAY_HALT || $halt === ErrorCore::DISPLAY_CONTINUE) {
-				if(PHP_SAPI === 'cli' && $e instanceof Exception) {
-					echo str_repeat('=', 80).PHP_EOL;
-					echo $e;
-					echo PHP_EOL.str_repeat('=', 80).PHP_EOL;
-				} else {
-					echo $html;
-				}
-				
-				if($halt === ErrorCore::DISPLAY_HALT) {
-					core_halt();
-				}
-			}
-		}
-	}
-
-	
 }
-	
-
-if(!function_exists('dump')) {
-	function dump(&$var, $info = FALSE)	{
-    	$scope = false;
-	    $prefix = 'unique';
-    	$suffix = 'value';
-
-	    if($scope) $vals = $scope;
-    	else $vals = $GLOBALS;
-
-	    $old = $var;
-    	$var = $new = $prefix.rand().$suffix; $vname = FALSE;
-	    foreach($vals as $key => $val) if($val === $new) $vname = $key;
-    	$var = $old;
-
-	    ob_end_flush();
-    	ob_start();
-	    if($info != FALSE) echo "<b style='color: red;'>$info:</b><br>";
-    	do_dump($var, '$'.$vname);
-	    $buf = ob_get_clean();
-    	return $buf;
-    }
-}
-
-if(!function_exists('do_dump')) {
-	////////////////////////////////////////////////////////
-	// Function:         do_dump
-	// Inspired from:     PHP.net Contributions
-	// Description: Better GI than print_r or var_dump
-	
-	function do_dump(&$var, $var_name = NULL, $indent = NULL, $reference = NULL) {
-		
-	    $do_dump_indent = "<span style='color:#eeeeee;'>|</span> &nbsp;&nbsp; ";
-	    $reference = $reference.$var_name;
-	    $keyvar = 'the_do_dump_recursion_protection_scheme'; $keyname = 'referenced_object_name';
-	
-	    #$var = '';
-	    if (is_array($var) && isset($var[$keyvar]))
-	    {
-	        $real_var = &$var[$keyvar];
-	        $real_name = &$var[$keyname];
-	        $type = ucfirst(gettype($real_var));
-	        echo "$indent$var_name <span style='color:#a2a2a2'>$type</span> = <span style='color:#e87800;'>&amp;$real_name</span><br>";
-	    }
-	    else
-	    {
-	        $var = array($keyvar => $var, $keyname => $reference);
-	        $avar = &$var[$keyvar];
-	
-	        $type = ucfirst(gettype($avar));
-	        if($type == "String") $type_color = "<span style='color:green'>";
-	        elseif($type == "Integer") $type_color = "<span style='color:red'>";
-	        elseif($type == "Double"){ $type_color = "<span style='color:#0099c5'>"; $type = "Float"; }
-	        elseif($type == "Boolean") $type_color = "<span style='color:#92008d'>";
-	        elseif($type == "NULL") $type_color = "<span style='color:black'>";
-	
-	        if(is_array($avar))
-	        {
-	            $count = count($avar);
-	            echo "$indent" . ($var_name ? "$var_name => ":"") . "<span style='color:#a2a2a2'>$type ($count)</span><br>$indent(<br>";
-	            $keys = array_keys($avar);
-	            foreach($keys as $name)
-	            {
-	                $value = &$avar[$name];
-	                do_dump($value, "['$name']", $indent.$do_dump_indent, $reference);
-	            }
-	            echo "$indent)<br>";
-	        }
-	        elseif(is_object($avar))
-	        {
-	            echo "$indent$var_name <span style='color:#a2a2a2'>$type</span><br>$indent(<br>";
-	            foreach($avar as $name=>$value) do_dump($value, "$name", $indent.$do_dump_indent, $reference);
-	            echo "$indent)<br>";
-	        }
-	        elseif(is_int($avar)) echo "$indent$var_name = <span style='color:#a2a2a2'>$type(".strlen($avar).")</span> $type_color$avar</span><br>";
-	        elseif(is_string($avar)) echo "$indent$var_name = <span style='color:#a2a2a2'>$type(".strlen($avar).")</span> $type_color\"$avar\"</span><br>";
-	        elseif(is_float($avar)) echo "$indent$var_name = <span style='color:#a2a2a2'>$type(".strlen($avar).")</span> $type_color$avar</span><br>";
-	        elseif(is_bool($avar)) echo "$indent$var_name = <span style='color:#a2a2a2'>$type(".strlen($avar).")</span> $type_color".($avar == 1 ? "TRUE":"FALSE")."</span><br>";
-	        elseif(is_null($avar)) echo "$indent$var_name = <span style='color:#a2a2a2'>$type(".strlen($avar).")</span> {$type_color}NULL</span><br>";
-	        else echo "$indent$var_name = <span style='color:#a2a2a2'>$type(".strlen($avar).")</span> $avar<br>";
-	
-	        $var = $var[$keyvar];
-	    }
-	}
-}
-
-

--- a/objects/Database.php
+++ b/objects/Database.php
@@ -392,11 +392,8 @@ class Database {
 	 *
 	 */
 	public static function error() {
-		
 		if(!self::$debug) exit();
-		
-		throw new DatabaseException(mysqli_connect_error(), mysqli_connect_errno());
-		
+		throw DatabaseException::factory(self::$connection);
 	}
 	
 	
@@ -637,8 +634,6 @@ class Database {
 		
 }
 
-
-
 class DatabaseCache {
 
 	private static $cache = array();
@@ -744,9 +739,6 @@ class DatabaseCache {
 
 
 }
-
-
-
 
 abstract class DatabaseQueryHelper {
 	
@@ -1163,9 +1155,6 @@ abstract class DatabaseQueryHelper {
 	
 }
 
-
-
-
 class DatabaseConnection extends DatabaseQueryHelper implements DatabaseConnectionInterface {
 
 	public $name;
@@ -1516,77 +1505,13 @@ class DatabaseConnection extends DatabaseQueryHelper implements DatabaseConnecti
     }
 	
 	
-    /**
-     * Parse the error message template
-     *
-     * @return string
-     */
-	public function get_errors($echo = TRUE) {
-		$output = ob_get_clean();
-		ob_start();
-		if(PHP_SAPI !== 'cli') {
-?>
-		
-		<h1>Database Error</h1>
-		
-		<p>We're sorry, but the system has encountered an error. We have notified technical support with the details of this error and they are working to get the problem resolved. Please try again later.</p>
-
-		<h2>MySQL Error <?=$this->error_code();?></h2>
-		
-		<h3>Description</h3>
-		<pre><?=$this->error_msg();?></pre>
-		
-		<h3>Query</h3>
-		<pre><?=$this->last_query();?></pre>
-
-		<h2>Most Recent Queries:</h2>
-<ol>
-<?php
-	foreach($this->query_history as $q) {
-		echo "<li><b>$q->file[$q->line]:</b>\n<pre>$q->query</pre></li>\n";
-	}
-?>
-</ol>
-		
-		
-<?php
-		} else {
-?>
-
-
-MySQL Error <?=$this->error_code();?>
-
---------------------
-<?=$this->error_msg();?>
-
-
-Query:
---------
-<?=$this->last_query();?>
-
-
-Recent Queries:
------------------
-<?php
-			foreach($this->query_history as $q) {
-				echo "$q->file[$q->line]:\n$q->query\n--\n";
-			}
-			echo "\n";
-		}
-		$errors = ob_get_clean();
-		echo $output;
-		if($echo) echo $errors;
-		return $errors;
-	}
-	
-	
 	/**
 	 * Database error handler
 	 *
 	 * @param boolean $exit
 	 */
 	public function handle_error($exit = TRUE) {
-		throw new DatabaseException($this->get_errors(FALSE), $this->error_code());
+		throw DatabaseException::factory($this);
 		if($exit) die;
 	}
 
@@ -1599,7 +1524,7 @@ Recent Queries:
 	 * @param boolean $exit
 	 */
 	public function handle_connection_error($exit = TRUE) {
-		throw new DatabaseConnectionException($this->get_errors(FALSE));
+		throw DatabaseConnectionException::factory($this);
 		if($exit) die;
 	}
 	
@@ -1680,9 +1605,6 @@ Recent Queries:
 	}
 	
 }
-
-
-
 
 class DatabaseQuery implements DatabaseQueryInterface {
 	
@@ -2420,8 +2342,6 @@ class DatabaseQuery implements DatabaseQueryInterface {
 	
 	
 }
-
-
 	
 class DatabaseResult implements DatabaseResultInterface {
 	
@@ -2987,9 +2907,6 @@ class DatabaseResult implements DatabaseResultInterface {
 }
 
 
-
-
-
 interface DatabaseConnectionInterface{
 	public function __construct($host = '', $user = '', $pass = '', $db = '', $debug = TRUE, $persist = TRUE);
 	public function __destruct();
@@ -3001,7 +2918,6 @@ interface DatabaseConnectionInterface{
 	public function error_msg();
 	public function handle_error($exit = TRUE);
 }
-
 
 interface DatabaseQueryInterface{
 	public function __construct(DatabaseConnection $connection, $table = NULL, $statement = NULL);
@@ -3021,7 +2937,6 @@ interface DatabaseQueryInterface{
 	public function run();
 }
 
-
 interface DatabaseResultInterface{
 	public function __construct(DatabaseConnection $connection, $qh, $sql = NULL, $time = NULL);
 	public function result();
@@ -3036,7 +2951,6 @@ interface DatabaseResultInterface{
 	public function null_set();
 	public function insert_id();
 }
-
 
 
 /**


### PR DESCRIPTION
Set `Config::set('SHOW_ERROR_TRACE', true);` to show detailed error traces in development.

Set `Config::set('RAVEN_DSN', ...);` to enable Sentry error reporting.

Composer dependencies:

* sentry/sentry
* filp/whoops