### PR TITLE
Remove svn dependency and security risk

### DIFF
--- a/core.php
+++ b/core.php
@@ -18,13 +18,6 @@ function core_execute() {
 			exit;
 		}
 		
-		# version headers
-		if(!headers_sent()) {
-			$core_rev = svn_get_version(PATH_CORE, FALSE);
-			$app_rev = svn_get_version(PATH_APP, FALSE);
-			@header("X-Core52-Version: core=$core_rev; app=$app_rev");
-		}
-		
 		# run the controller
 		ob_start();
 		if(defined('ENABLE_LEGACY_ROUTING')) {

--- a/initialize.php
+++ b/initialize.php
@@ -117,8 +117,7 @@
 		'object',
 		'email',
 		'json',
-		'ci/text_helper',
-		'svn',
+		'ci/text_helper'
 	), TRUE);
 	
 	# Load additional (custom) helpers


### PR DESCRIPTION
We shouldn’t expose information about the software stack for security reasons.