### PR TITLE
Fix HttpOnly flag on session cookies

### DIFF
--- a/objects/Session.php
+++ b/objects/Session.php
@@ -768,7 +768,7 @@ DEBUG;
 				'/',                   // cookie path
 				$this->domain,         // cookie domain
 				(Router::protocol() == 'https' && $this->secure_cookies), // transmit only over https
-				$this->secure_cookies)   // HttpOnly flag
+				$this->secure_cookies   // HttpOnly flag
 			);
 
 			// start the session

--- a/objects/Session.php
+++ b/objects/Session.php
@@ -768,7 +768,7 @@ DEBUG;
 				'/',                   // cookie path
 				$this->domain,         // cookie domain
 				(Router::protocol() == 'https' && $this->secure_cookies), // transmit only over https
-				(Router::protocol() == 'http' && $this->secure_cookies)   // set the HTTPONLY flag if supported
+				$this->secure_cookies)   // HttpOnly flag
 			);
 
 			// start the session


### PR DESCRIPTION
The HttpOnly flag prevents javascript in the browser from being able to access the cookie. It has nothing to do with whether HTTP vs HTTPS is being used. This will allow the flag to be set in both cases.